### PR TITLE
Handle discriminated unions with a generic parameter

### DIFF
--- a/test/ProtoBuf.FSharp.Unit/TestUnionRoundtrip.fs
+++ b/test/ProtoBuf.FSharp.Unit/TestUnionRoundtrip.fs
@@ -44,6 +44,15 @@ module ExampleTypesInsideModule =
     [<RequireQualifiedAccess; TestName("Single case union with data")>]
     type UnionEight = | One of int option * two: int array
 
+    [<TestName("Union with generic; two cases")>]
+    type SerialisableOption<'t> = 
+        | SerialisableSome of 't
+        | SerialisableNone
+
+    [<TestName("Union with generic; single case union")>]
+    type Wrapper<'t> = | Wrapper of 't
+
+
 module TestUnionRoundtrip =
 
     let propertyToTest<'t when 't : equality> (typeToTest: 't) = 
@@ -73,4 +82,6 @@ module TestUnionRoundtrip =
               buildTest<ExampleTypesInsideModule.UnionFive>()
               buildTest<ExampleTypesInsideModule.UnionSix>()
               buildTest<ExampleTypesInsideModule.UnionSeven>()
-              buildTest<ExampleTypesInsideModule.UnionEight>() ]
+              buildTest<ExampleTypesInsideModule.UnionEight>()
+              buildTest<ExampleTypesInsideModule.SerialisableOption<string>>() 
+              buildTest<ExampleTypesInsideModule.Wrapper<string>>() ]


### PR DESCRIPTION
This PR adds support for generic DU's (e.g. Wrapper<string>). You still need to register each instantiation of the generic type you want to serialise.