### PR TITLE
Value type surrogates + using regular constructor for records

### DIFF
--- a/src/ProtoBuf.FSharp/CodeGen.fs
+++ b/src/ProtoBuf.FSharp/CodeGen.fs
@@ -1,0 +1,133 @@
+module private ProtoBuf.FSharp.CodeGen
+
+open System
+open FSharp.Reflection
+open System.Collections.Concurrent
+open System.Reflection
+open System.Reflection.Emit
+
+
+let private emitFieldAssignments (gen : ILGenerator, assigns : struct (FieldInfo * MethodInfo)[]) =
+    for (fi, getValue) in assigns do
+        if fi.IsStatic then
+            gen.EmitCall(OpCodes.Call, getValue, null)
+            gen.Emit(OpCodes.Stsfld, fi)
+        else
+            gen.Emit(OpCodes.Dup)
+            gen.EmitCall(OpCodes.Call, getValue, null)
+            gen.Emit(OpCodes.Stfld, fi)
+
+
+let private emitFactory (resultType : Type, assigns) =
+    let factoryMethod = DynamicMethod("factory_" + resultType.FullName, resultType, [| |], true)
+    let gen = factoryMethod.GetILGenerator()
+
+    match resultType.GetConstructor [| |] with
+    | null when FSharpType.IsRecord (resultType, true) ->
+        for pi in FSharpType.GetRecordFields (resultType, true) do
+            let tp = pi.PropertyType
+            match ZeroValues.calculateIfApplicable tp with
+            | Some getValue -> gen.EmitCall(OpCodes.Call, getValue, null)
+            | _ when tp.IsValueType ->
+                let cell = gen.DeclareLocal(tp)
+                gen.Emit(OpCodes.Ldloca_S, cell)
+            | _ -> gen.Emit(OpCodes.Ldnull)
+        let ctr = FSharpValue.PreComputeRecordConstructorInfo (resultType, true)
+        gen.Emit (OpCodes.Newobj, ctr)
+    | null ->
+        gen.Emit(OpCodes.Ldtoken, resultType)
+        gen.EmitCall(OpCodes.Call, MethodHelpers.getMethodInfo <@ Runtime.Serialization.FormatterServices.GetUninitializedObject @> [||], null)
+        emitFieldAssignments (gen, assigns)
+    | ctr ->
+        gen.Emit (OpCodes.Newobj, ctr)
+        emitFieldAssignments (gen, assigns)
+
+    gen.Emit(OpCodes.Ret)
+    factoryMethod :> MethodInfo
+
+
+let private emitRecordSurrogate (surrogateModule : ModuleBuilder, recordType : Type, useValueTypeSurrogate : bool) =
+    let surrogateType =
+        let name = recordType.Name + "Surrogate"
+        let attr = TypeAttributes.Public ||| TypeAttributes.Sealed ||| TypeAttributes.Serializable
+        if useValueTypeSurrogate then
+            surrogateModule.DefineType (name, attr, typeof<ValueType>)
+        else
+            surrogateModule.DefineType (name, attr)
+
+    let surrogateFields = [|
+        for fi in FSharpType.GetRecordFields (recordType, true) ->
+            struct (fi, surrogateType.DefineField (fi.Name, fi.PropertyType, FieldAttributes.Public))
+    |]
+
+    let constructor =
+        let ctr = surrogateType.DefineConstructor (MethodAttributes.Public, CallingConventions.Standard, [| |])
+        let gen = ctr.GetILGenerator ()
+        for (field, surrogateField) in surrogateFields do
+            ZeroValues.calculateIfApplicable field.PropertyType |> Option.iter (fun getValue ->
+                gen.Emit((if surrogateType.IsValueType then OpCodes.Ldarga_S else OpCodes.Ldarg), 0)
+                gen.EmitCall(OpCodes.Call, getValue, null)
+                gen.Emit(OpCodes.Stfld, surrogateField)
+            )
+        gen.Emit(OpCodes.Ret)
+        ctr
+
+    let attr = MethodAttributes.Public ||| MethodAttributes.HideBySig ||| MethodAttributes.SpecialName ||| MethodAttributes.Static
+    do
+        let conv = surrogateType.DefineMethod ("op_Implicit", attr, recordType, [| surrogateType |])
+        let gen = conv.GetILGenerator ()
+        let ctr = FSharpValue.PreComputeRecordConstructorInfo (recordType, true)
+        for (_, surrogateField) in surrogateFields do
+            gen.Emit((if surrogateType.IsValueType then OpCodes.Ldarga_S else OpCodes.Ldarg), 0)
+            gen.Emit(OpCodes.Ldfld, surrogateField)
+        gen.Emit(OpCodes.Newobj, ctr)
+        gen.Emit(OpCodes.Ret)
+
+    do
+        let conv = surrogateType.DefineMethod ("op_Implicit", attr, surrogateType, [| recordType |])
+        let gen = conv.GetILGenerator ()
+        gen.Emit(OpCodes.Newobj, constructor)
+
+        let toEnd = gen.DefineLabel()
+        if not recordType.IsValueType then
+            gen.Emit(OpCodes.Ldarg_0)
+            gen.Emit(OpCodes.Brfalse, toEnd)
+
+        let cell = gen.DeclareLocal(surrogateType)
+        gen.Emit(OpCodes.Stloc, cell)
+        for (recordField, surrogateField) in surrogateFields do
+            gen.Emit((if surrogateType.IsValueType then OpCodes.Ldloca_S else OpCodes.Ldloc), cell)
+            gen.Emit((if recordType.IsValueType then OpCodes.Ldarga_S else OpCodes.Ldarg), 0)
+            gen.Emit(OpCodes.Call, recordField.GetMethod)
+            gen.Emit(OpCodes.Stfld, surrogateField)
+        gen.Emit(OpCodes.Ldloc, cell)
+
+        gen.MarkLabel(toEnd)
+        gen.Emit(OpCodes.Ret)
+
+    surrogateType.CreateTypeInfo ()
+
+
+[<Struct; RequireQualifiedAccess>]
+type MetaInfoType =
+    | JustFields
+    | FieldsAndFactory of factoryMethod : MethodInfo
+    | Surrogate of surrogateType : TypeInfo
+
+
+let private surrogateAssembly = AssemblyBuilder.DefineDynamicAssembly (AssemblyName("SurrogateAssembly"), AssemblyBuilderAccess.Run)
+let private surrogateModule = surrogateAssembly.DefineDynamicModule "SurrogateModule"
+
+let private metaInfoTypeCache = ConcurrentDictionary<Type, MetaInfoType> ()
+
+let getMetaInfoType (typeToAdd : Type, fields : FieldInfo[]) =
+    let assigns = ZeroValues.calculateApplicableFields fields
+    if Array.isEmpty assigns then
+        MetaInfoType.JustFields
+    else
+        metaInfoTypeCache.GetOrAdd (typeToAdd, fun _ ->
+            if typeToAdd.IsValueType && FSharpType.IsRecord (typeToAdd, true) then
+                emitRecordSurrogate (surrogateModule, typeToAdd, typeToAdd.IsValueType) |> MetaInfoType.Surrogate
+            else
+                emitFactory (typeToAdd, assigns) |> MetaInfoType.FieldsAndFactory
+        )

--- a/src/ProtoBuf.FSharp/MethodHelpers.fs
+++ b/src/ProtoBuf.FSharp/MethodHelpers.fs
@@ -1,0 +1,21 @@
+module private ProtoBuf.FSharp.MethodHelpers
+
+open System
+open Microsoft.FSharp.Quotations.Patterns
+open System.Reflection
+
+
+/// Allows you to get the nameof a method in older F# versions
+let private nameOfQuotation methodQuotation =
+    match methodQuotation with
+    | Lambda(_, Call(_, mi, _))
+    | Lambda(_, Lambda(_, Call(_, mi, _))) -> mi.DeclaringType, mi.Name
+    | x -> failwithf "Not supported %A" x
+
+let private bindingFlagsToUse = BindingFlags.Public ||| BindingFlags.NonPublic ||| BindingFlags.Static
+
+let getMethodInfo quotation (typeParameters: Type array) =
+    let (declaringType, nameOfMethod) = nameOfQuotation quotation
+    match typeParameters.Length with
+    | 0 -> declaringType.GetMethod(nameOfMethod, bindingFlagsToUse)
+    | _ -> declaringType.GetMethod(nameOfMethod, bindingFlagsToUse).MakeGenericMethod(typeParameters)

--- a/src/ProtoBuf.FSharp/ProtoBuf.FSharp.fsproj
+++ b/src/ProtoBuf.FSharp/ProtoBuf.FSharp.fsproj
@@ -6,6 +6,10 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Surrogates.fs" />
+    <Compile Include="MethodHelpers.fs" />
+    <Compile Include="ZeroValues.fs" />
+    <Compile Include="CodeGen.fs" />
     <Compile Include="ProtobufUtils.fs" />
     <Content Include="app.config" />
   </ItemGroup>

--- a/src/ProtoBuf.FSharp/Surrogates.fs
+++ b/src/ProtoBuf.FSharp/Surrogates.fs
@@ -1,0 +1,12 @@
+module private ProtoBuf.FSharp.Surrogates
+
+
+type [<CLIMutable>] Optional<'t> =
+    { HasValue: bool
+      Item: 't }
+    static member op_Implicit (w: Optional<'t>) : 't option =
+        if w.HasValue then Some w.Item else None
+    static member op_Implicit (o: 't option) =
+        match o with
+        | Some(o) -> { Item = o; HasValue = true }
+        | None -> { HasValue = false; Item = Unchecked.defaultof<_> }

--- a/src/ProtoBuf.FSharp/Surrogates.fs
+++ b/src/ProtoBuf.FSharp/Surrogates.fs
@@ -1,4 +1,4 @@
-module private ProtoBuf.FSharp.Surrogates
+namespace ProtoBuf.FSharp.Surrogates
 
 
 type [<CLIMutable>] Optional<'t> =

--- a/src/ProtoBuf.FSharp/ZeroValues.fs
+++ b/src/ProtoBuf.FSharp/ZeroValues.fs
@@ -1,0 +1,47 @@
+module ProtoBuf.FSharp.ZeroValues
+
+open System
+open System.Collections.Concurrent
+open System.Reflection
+
+
+let GetEmptyString() : string = String.Empty
+let GetEmptyFSharpList<'t>() : 't list = List.empty
+let GetEmptyArray<'t>() : 't array = Array.empty
+let GetEmptySet<'t when 't : comparison>() : Set<'t> = Set.empty
+let GetEmptyMap<'t, 'tv when 't : comparison>() : Map<'t, 'tv> = Map.empty
+
+
+let private zeroValues = ConcurrentDictionary<Type, MethodInfo>()
+
+let calculateIfApplicable (fieldType: Type) =
+    /// Creates the zero value for supported types that we know of.
+    let createZeroValue() =
+        if fieldType = typeof<string> then
+            MethodHelpers.getMethodInfo <@ GetEmptyString @> [| |] |> Some
+        elif fieldType.IsGenericType && fieldType.GetGenericTypeDefinition() = typedefof<_ list> then
+            MethodHelpers.getMethodInfo <@ GetEmptyFSharpList @> fieldType.GenericTypeArguments |> Some
+        elif fieldType.IsGenericType && fieldType.GetGenericTypeDefinition() = typedefof<Set<_>> then
+            MethodHelpers.getMethodInfo <@ GetEmptySet @> fieldType.GenericTypeArguments |> Some
+        elif fieldType.IsGenericType && fieldType.GetGenericTypeDefinition() = typedefof<Map<_, _>> then
+            MethodHelpers.getMethodInfo <@ GetEmptyMap @> fieldType.GenericTypeArguments |> Some
+        elif fieldType.IsArray then
+            MethodHelpers.getMethodInfo <@ GetEmptyArray @> [| fieldType.GetElementType() |] |> Some
+        else None
+
+    match zeroValues.TryGetValue(fieldType) with
+    | (true, zeroValue) -> Some zeroValue
+    | (false, _) ->
+        match createZeroValue() with
+        | Some(zeroValue) ->
+            zeroValues.[fieldType] <- zeroValue
+            Some zeroValue
+        | None -> None
+
+
+let calculateApplicableFields (fields: FieldInfo[]) =
+    [|  for fi in fields do
+            match calculateIfApplicable fi.FieldType with
+                | None -> ()
+                | Some zeroValue -> yield struct (fi, zeroValue)
+    |]

--- a/src/ProtoBuf.FSharp/ZeroValues.fs
+++ b/src/ProtoBuf.FSharp/ZeroValues.fs
@@ -5,11 +5,15 @@ open System.Collections.Concurrent
 open System.Reflection
 
 
-let GetEmptyString() : string = String.Empty
-let GetEmptyFSharpList<'t>() : 't list = List.empty
-let GetEmptyArray<'t>() : 't array = Array.empty
-let GetEmptySet<'t when 't : comparison>() : Set<'t> = Set.empty
-let GetEmptyMap<'t, 'tv when 't : comparison>() : Map<'t, 'tv> = Map.empty
+let getEmptyString() : string = String.Empty
+
+let getEmptyFSharpList<'t>() : 't list = List.empty
+
+let getEmptyArray<'t>() : 't array = Array.empty
+
+let getEmptySet<'t when 't : comparison>() : Set<'t> = Set.empty
+
+let getEmptyMap<'t, 'tv when 't : comparison>() : Map<'t, 'tv> = Map.empty
 
 
 let private zeroValues = ConcurrentDictionary<Type, MethodInfo>()
@@ -18,15 +22,15 @@ let calculateIfApplicable (fieldType: Type) =
     /// Creates the zero value for supported types that we know of.
     let createZeroValue() =
         if fieldType = typeof<string> then
-            MethodHelpers.getMethodInfo <@ GetEmptyString @> [| |] |> Some
+            MethodHelpers.getMethodInfo <@ getEmptyString @> [| |] |> Some
         elif fieldType.IsGenericType && fieldType.GetGenericTypeDefinition() = typedefof<_ list> then
-            MethodHelpers.getMethodInfo <@ GetEmptyFSharpList @> fieldType.GenericTypeArguments |> Some
+            MethodHelpers.getMethodInfo <@ getEmptyFSharpList @> fieldType.GenericTypeArguments |> Some
         elif fieldType.IsGenericType && fieldType.GetGenericTypeDefinition() = typedefof<Set<_>> then
-            MethodHelpers.getMethodInfo <@ GetEmptySet @> fieldType.GenericTypeArguments |> Some
+            MethodHelpers.getMethodInfo <@ getEmptySet @> fieldType.GenericTypeArguments |> Some
         elif fieldType.IsGenericType && fieldType.GetGenericTypeDefinition() = typedefof<Map<_, _>> then
-            MethodHelpers.getMethodInfo <@ GetEmptyMap @> fieldType.GenericTypeArguments |> Some
+            MethodHelpers.getMethodInfo <@ getEmptyMap @> fieldType.GenericTypeArguments |> Some
         elif fieldType.IsArray then
-            MethodHelpers.getMethodInfo <@ GetEmptyArray @> [| fieldType.GetElementType() |] |> Some
+            MethodHelpers.getMethodInfo <@ getEmptyArray @> [| fieldType.GetElementType() |] |> Some
         else None
 
     match zeroValues.TryGetValue(fieldType) with

--- a/test/ProtoBuf.FSharp.Unit/TestRecordRoundtrip.fs
+++ b/test/ProtoBuf.FSharp.Unit/TestRecordRoundtrip.fs
@@ -31,11 +31,23 @@ type TestRecordFour = {
 
 // Struct records are not supported due to limitation of protobuf-net.
 // See https://github.com/protobuf-net/protobuf-net/blob/3.0.62/src/protobuf-net/Meta/RuntimeTypeModel.cs#L1971 (currrent at time of code commit)
-// [<Struct; TestName("Struct Record">]
-// type TestRecordFive = {
-//     Flag : bool
-//     String : string
-// }
+[<Struct; TestName("Struct Record")>]
+type TestRecordFive = {
+    Flag : bool
+    String : string
+}
+
+[<TestName("Internal Record")>]
+type TestRecordSix = internal {
+    Flag : bool
+    String : string
+}
+
+[<Struct; TestName("Struct Record with weird field names")>]
+type TestRecordSeven = {
+    ``__$uperF!eld__`` : bool
+    ``String#`` : string
+}
 
 module TestRecordRoundtrip = 
 
@@ -90,6 +102,8 @@ module TestRecordRoundtrip =
               yield buildTest<TestRecordTwo>
               yield buildTest<TestRecordThree>
               yield buildTest<TestRecordFour>
-              //yield buildTest<TestRecordFive> // See comment on type for why this isn't supported currently.
+              yield buildTest<TestRecordFive> // See comment on type for why this isn't supported currently.
+              yield buildTest<TestRecordSix>
+              yield buildTest<TestRecordSeven>
               yield! manualTestCases
             ]

--- a/test/ProtoBuf.FSharp.Unit/TestRecordRoundtrip.fs
+++ b/test/ProtoBuf.FSharp.Unit/TestRecordRoundtrip.fs
@@ -29,18 +29,26 @@ type TestRecordFour = {
     String : string
 }
 
-// Struct records are not supported due to limitation of protobuf-net.
-// See https://github.com/protobuf-net/protobuf-net/blob/3.0.62/src/protobuf-net/Meta/RuntimeTypeModel.cs#L1971 (currrent at time of code commit)
+
 [<Struct; TestName("Struct Record")>]
 type TestRecordFive = {
     Flag : bool
     String : string
 }
 
+type TestEnum =
+    | OptionA = 1uy
+    | OptionB = 2uy
+    | OptionC = 69uy
+
 [<TestName("Internal Record")>]
 type TestRecordSix = internal {
-    Flag : bool
+    Field : struct (int * bool * int64)
+    Number : int64
+    DecimalNumber : decimal
+    EnumField : TestEnum
     String : string
+    Date : System.DateTime
 }
 
 [<Struct; TestName("Struct Record with weird field names")>]
@@ -102,7 +110,7 @@ module TestRecordRoundtrip =
               yield buildTest<TestRecordTwo>
               yield buildTest<TestRecordThree>
               yield buildTest<TestRecordFour>
-              yield buildTest<TestRecordFive> // See comment on type for why this isn't supported currently.
+              yield buildTest<TestRecordFive>
               yield buildTest<TestRecordSix>
               yield buildTest<TestRecordSeven>
               yield! manualTestCases


### PR DESCRIPTION
Changes include:

- Surrogates are emitted for value type records if necessary (i.e. if fields of type from {string, Array<>, Map<, >, Set<>, List<>} are present; previously such records caused runtime error)
- Complete factory method is emitted instead of separate setters in all other cases where factory method is needed.
- Factory method for records now prefers using standard record constructor over Runtime.Serialization.FormatterServices.GetUninitializedObject.