### PR TITLE
Basic value unions implementation

### DIFF
--- a/src/ProtoBuf.FSharp/CodeGen.fs
+++ b/src/ProtoBuf.FSharp/CodeGen.fs
@@ -19,6 +19,16 @@ let inline emitZeroValueOntoEvaluationStack (gen: ILGenerator) (getterType: Meth
         gen.Emit(OpCodes.Ldc_I4_0) // Push length onto the stack.
         gen.Emit(OpCodes.Newarr, elementType) // Initialise array with length.
 
+let private emitStackTopZeroCheck (gen : ILGenerator) (topType : Type) =
+    ZeroValues.getZeroValueMethodInfoOpt topType |> Option.iter (fun getValue ->
+        let skip = gen.DefineLabel()
+        gen.Emit(OpCodes.Dup)
+        gen.Emit(OpCodes.Brtrue, skip)
+        gen.Emit(OpCodes.Pop)
+        emitZeroValueOntoEvaluationStack gen getValue
+        gen.MarkLabel(skip)
+    )
+
 let private emitFieldAssignments (gen: ILGenerator) (zeroValuesPerField: ZeroValues.FieldWithZeroValueSetMethod[]) =
     for zeroValueField in zeroValuesPerField do
         if zeroValueField.FieldInfo.IsStatic then
@@ -66,19 +76,14 @@ let private emitFactory (resultType : Type) (zeroValuesPerField: ZeroValues.Fiel
     gen.Emit(OpCodes.Ret)
     factoryMethod :> MethodInfo
 
-/// Emits a record surrogate. Intended to be used to support value type records ONLY since Protobuf-net at time of writing does not support custom ValueTypes/Structs.
-let private emitRecordSurrogate (surrogateModule: ModuleBuilder) (recordType: Type) (useValueTypeSurrogate: bool) =
+
+let surrogateTypeDeclaration (surrogateModule: ModuleBuilder) (targetType: Type) (useValueTypeSurrogate: bool) =
     let surrogateType =
-        let name = sprintf "%s.Generated.%s" (nameof ProtoBuf.FSharp.Surrogates) recordType.FullName
+        let name = sprintf "ProtoBuf.FSharp.Surrogates.Generated.%s" targetType.FullName
         let attr = TypeAttributes.Public ||| TypeAttributes.Sealed ||| TypeAttributes.Serializable
         if useValueTypeSurrogate
         then surrogateModule.DefineType(name, attr, typeof<ValueType>)
         else surrogateModule.DefineType(name, attr)
-
-    let surrogateFields = [|
-        for fi in FSharpType.GetRecordFields(recordType, true) ->
-            struct (fi, surrogateType.DefineField(fi.Name, fi.PropertyType, FieldAttributes.Public))
-    |]
 
     let constructor =
         if surrogateType.IsValueType
@@ -91,24 +96,27 @@ let private emitRecordSurrogate (surrogateModule: ModuleBuilder) (recordType: Ty
             gen.Emit(OpCodes.Ret)
             ValueSome ctr
 
+    struct (surrogateType, constructor)
+
+/// Emits a record surrogate. Intended to be used to support value type records ONLY since Protobuf-net at time of writing does not support custom ValueTypes/Structs.
+let private emitRecordSurrogate (surrogateModule: ModuleBuilder) (recordType: Type) (useValueTypeSurrogate: bool) =
+    let struct (surrogateType, constructor) = surrogateTypeDeclaration surrogateModule recordType useValueTypeSurrogate
+
+    let surrogateFields = [|
+        for fi in FSharpType.GetRecordFields(recordType, true) ->
+            struct (fi, surrogateType.DefineField(fi.Name, fi.PropertyType, FieldAttributes.Public))
+    |]
+
     let attr = MethodAttributes.Public ||| MethodAttributes.HideBySig ||| MethodAttributes.SpecialName ||| MethodAttributes.Static
 
     // Define op_Implicit methods that Protobuf calls to create recordType from surrogate.
     let conv = surrogateType.DefineMethod("op_Implicit", attr, recordType, [| surrogateType |])
     let gen = conv.GetILGenerator()
-    let ctr = FSharpValue.PreComputeRecordConstructorInfo(recordType, true)
     for (recordField, surrogateField) in surrogateFields do
         gen.Emit((if surrogateType.IsValueType then OpCodes.Ldarga_S else OpCodes.Ldarg), 0)
         gen.Emit(OpCodes.Ldfld, surrogateField)
-        ZeroValues.getZeroValueMethodInfoOpt recordField.PropertyType |> Option.iter (fun getValue ->
-            let skip = gen.DefineLabel()
-            gen.Emit(OpCodes.Dup)
-            gen.Emit(OpCodes.Brtrue, skip)
-            gen.Emit(OpCodes.Pop)
-            emitZeroValueOntoEvaluationStack gen getValue
-            gen.MarkLabel(skip)
-        )
-    gen.Emit(OpCodes.Newobj, ctr)
+        emitStackTopZeroCheck gen recordField.PropertyType
+    gen.Emit(OpCodes.Newobj, FSharpValue.PreComputeRecordConstructorInfo(recordType, true))
     gen.Emit(OpCodes.Ret)
 
     // Define op_Implicit methods that Protobuf calls to create surrogate from recordType.
@@ -142,6 +150,88 @@ let private emitRecordSurrogate (surrogateModule: ModuleBuilder) (recordType: Ty
 
     surrogateType.CreateTypeInfo ()
 
+let private emitValueUnionSurrogate (surrogateModule: ModuleBuilder) (unionType: Type) (useValueTypeSurrogate: bool) =
+    let struct (surrogateType, constructor) = surrogateTypeDeclaration surrogateModule unionType useValueTypeSurrogate
+
+    let cases = [|
+        for caseInfo in FSharpType.GetUnionCases(unionType, true) ->
+            struct (caseInfo, [|
+                for fi in caseInfo.GetFields() ->
+                    struct (fi, surrogateType.DefineField(fi.Name, fi.PropertyType, FieldAttributes.Public))
+            |])
+    |]
+
+    let surrogateTagField =
+        let rec chooseName name =
+            match unionType.GetMember(name, BindingFlags.Public ||| BindingFlags.NonPublic) with
+            | [||] -> name
+            | _ -> chooseName ("_" + name)
+        surrogateType.DefineField(chooseName "__tag", typeof<int>, FieldAttributes.Public)
+
+    let attr = MethodAttributes.Public ||| MethodAttributes.HideBySig ||| MethodAttributes.SpecialName ||| MethodAttributes.Static
+
+    // Define op_Implicit methods that Protobuf calls to create unionType from surrogate.
+    begin
+        let conv = surrogateType.DefineMethod("op_Implicit", attr, unionType, [| surrogateType |])
+        let gen = conv.GetILGenerator()
+
+        let jumpTable = Array.init (Array.length cases) (ignore >> gen.DefineLabel)
+
+        gen.Emit((if surrogateType.IsValueType then OpCodes.Ldarga_S else OpCodes.Ldarg), 0)
+        gen.Emit(OpCodes.Ldfld, surrogateTagField)
+        gen.Emit(OpCodes.Switch, jumpTable)
+
+        for (caseInfo, surrogateFields) in cases do
+            gen.MarkLabel(jumpTable.[ caseInfo.Tag ])
+            for (originField, surrogateField) in surrogateFields do
+                gen.Emit((if surrogateType.IsValueType then OpCodes.Ldarga_S else OpCodes.Ldarg), 0)
+                gen.Emit(OpCodes.Ldfld, surrogateField)
+                emitStackTopZeroCheck gen originField.PropertyType
+            gen.Emit(OpCodes.Call, FSharpValue.PreComputeUnionConstructorInfo(caseInfo, true))
+            gen.Emit(OpCodes.Ret)
+    end
+
+    // Define op_Implicit methods that Protobuf calls to create surrogate from unionType.
+    begin
+        let conv = surrogateType.DefineMethod("op_Implicit", attr, surrogateType, [| unionType |])
+        let gen = conv.GetILGenerator()
+
+        let resultCell = gen.DeclareLocal(surrogateType)
+        match constructor with
+        | ValueSome ctr ->
+            gen.Emit(OpCodes.Newobj, ctr)
+            gen.Emit(OpCodes.Stloc, resultCell)
+        | ValueNone ->
+            gen.Emit(OpCodes.Ldloca_S, resultCell)
+            gen.Emit(OpCodes.Initobj, surrogateType)
+
+        let jumpTable = Array.init (Array.length cases) (ignore >> gen.DefineLabel)
+
+        match FSharpValue.PreComputeUnionTagMemberInfo(unionType, true) with
+        | :? PropertyInfo as tag ->
+            gen.Emit((if unionType.IsValueType then OpCodes.Ldarga_S else OpCodes.Ldarg), 0)
+            gen.Emit(OpCodes.Call, tag.GetMethod)
+        | :? MethodInfo as tag when tag.IsStatic ->
+            gen.Emit(OpCodes.Call, tag)
+        | smth -> failwithf "Unexpected tag member: %A" smth
+        gen.Emit(OpCodes.Switch, jumpTable)
+
+        for (caseInfo, surrogateFields) in cases do
+            gen.MarkLabel(jumpTable.[ caseInfo.Tag ])
+            gen.Emit((if surrogateType.IsValueType then OpCodes.Ldloca_S else OpCodes.Ldloc), resultCell)
+            for (originField, surrogateField) in surrogateFields do
+                gen.Emit(OpCodes.Dup)
+                gen.Emit(OpCodes.Ldarga_S, 0)
+                gen.Emit(OpCodes.Call, originField.GetMethod)
+                gen.Emit(OpCodes.Stfld, surrogateField)
+            gen.Emit(OpCodes.Ldc_I4, caseInfo.Tag)
+            gen.Emit(OpCodes.Stfld, surrogateTagField)
+            gen.Emit(OpCodes.Ldloc, resultCell)
+            gen.Emit(OpCodes.Ret)
+    end
+
+    surrogateType.CreateTypeInfo ()
+
 [<RequireQualifiedAccess>]
 type internal TypeConstructionStrategy =
     | NoCustomConstructor // Uses default Protobuf-net behaviour
@@ -158,7 +248,9 @@ let getTypeConstructionMethod (typeToAdd : Type) (fields : FieldInfo[]) =
     then TypeConstructionStrategy.NoCustomConstructor
     else
         metaInfoTypeCache.GetOrAdd(typeToAdd, fun _ ->
-            if typeToAdd.IsValueType && FSharpType.IsRecord (typeToAdd, true)
-            then emitRecordSurrogate surrogateModule typeToAdd typeToAdd.IsValueType |> TypeConstructionStrategy.ObjectSurrogate
+            if typeToAdd.IsValueType && FSharpType.IsRecord (typeToAdd, true) then
+                emitRecordSurrogate surrogateModule typeToAdd typeToAdd.IsValueType |> TypeConstructionStrategy.ObjectSurrogate
+            elif typeToAdd.IsValueType && FSharpType.IsUnion (typeToAdd, true) then
+                emitValueUnionSurrogate surrogateModule typeToAdd true |> TypeConstructionStrategy.ObjectSurrogate
             else emitFactory typeToAdd zeroValuesForFields |> TypeConstructionStrategy.CustomFactoryMethod
         )

--- a/src/ProtoBuf.FSharp/ProtobufUtils.fs
+++ b/src/ProtoBuf.FSharp/ProtobufUtils.fs
@@ -48,7 +48,6 @@ module Serialiser =
         metaType.UseConstructor <- false
         match CodeGen.getTypeConstructionMethod typeToAdd fields with
         | CodeGen.TypeConstructionStrategy.ObjectSurrogate surrogateType ->
-            model.Add(surrogateType, true) |> ignore
             metaType.SetSurrogate surrogateType
         | CodeGen.TypeConstructionStrategy.CustomFactoryMethod factoryMethod ->
             addFieldsToMetaType metaType fields
@@ -57,6 +56,14 @@ module Serialiser =
             addFieldsToMetaType metaType fields
 
         for field in fields do registerOptionTypesIntoModel field.FieldType None model
+
+    let registerUnionRuntimeTypeIntoModel' (unionType: Type) (model: RuntimeTypeModel) =
+        let metaType = model.Add(unionType, true)
+        let surrogateType = CodeGen.getUnionSurrogate unionType
+        metaType.SetSurrogate surrogateType
+        for subtype in CodeGen.relevantUnionSubtypes unionType do
+            model.Add(subtype, false).SetSurrogate(surrogateType)
+        model
 
     let registerUnionRuntimeTypeIntoModel (unionType: Type) (model: RuntimeTypeModel) =
         let unionCaseData = FSharpType.GetUnionCases(unionType, true)

--- a/src/ProtoBuf.FSharp/ProtobufUtils.fs
+++ b/src/ProtoBuf.FSharp/ProtobufUtils.fs
@@ -52,7 +52,7 @@ module Serialiser =
         match CodeGen.getTypeConstructionMethod typeToAdd fields with
         | CodeGen.TypeConstructionStrategy.ObjectSurrogate surrogateType ->
             let surrogateMetaType = model.Add(surrogateType, false)
-            surrogateMetaType.UseConstructor <- true
+            surrogateMetaType.UseConstructor <- not surrogateType.IsValueType
             let surrogateTypeFields = surrogateType.GetFields(BindingFlags.Public ||| BindingFlags.NonPublic ||| BindingFlags.Instance ||| BindingFlags.GetField)
             addFieldsToMetaType surrogateMetaType surrogateTypeFields
             metaType.SetSurrogate surrogateType

--- a/src/ProtoBuf.FSharp/ProtobufUtils.fs
+++ b/src/ProtoBuf.FSharp/ProtobufUtils.fs
@@ -8,6 +8,13 @@ open System.Reflection
 open System.IO
 
 module Serialiser =
+    let private registerSurrogate (tp : Type) (model : RuntimeTypeModel) =
+        let surrogateType = CodeGen.getSurrogate tp
+        match surrogateType.GetMethod("RegisterIntoModel") with
+        | null -> ()
+        | method -> method.Invoke(null, [| box model |]) |> ignore
+        model.Add(tp, false).SetSurrogate surrogateType
+        surrogateType
 
     /// The magic number where if a union type has more than the above cases it simply is a tagged instance of the parent type.
     /// Otherwise for this number and below even non-empty unions get their own inner class prefixed with "_".
@@ -25,53 +32,32 @@ module Serialiser =
                 let m = m :?> MetaType
                 yield m.Type
             }
-
-            if  definedTypes |> Seq.contains optionType |> not
+            if definedTypes |> Seq.contains optionType |> not
             then
-                let surrogateType = typedefof<Surrogates.Optional<_>>.MakeGenericType(optionType.GetGenericArguments())
-                let surrogateModelType = model.Add(surrogateType, false)
-                surrogateModelType.Name <- "Optional" + (customTypeSuffix |> Option.defaultValue (optionType.GetGenericArguments().[0].Name))
-                surrogateModelType.AddField(1, "HasValue") |> ignore
-                surrogateModelType.AddField(2, "Item") |> ignore
-                let mt = model.Add(optionType, false)
-                mt.SetSurrogate(surrogateType)
+                registerSurrogate optionType model |> ignore
 
-    let private addFieldsToMetaType (metaType : MetaType) (fields : FieldInfo[]) =
+    let private processFieldsAndCreateFieldSetters (typeToAdd: Type) (model : RuntimeTypeModel) =
+        let metaType = model.Add(typeToAdd, false)
+        metaType.UseConstructor <- false
+
+        let fields = typeToAdd.GetFields(BindingFlags.Public ||| BindingFlags.NonPublic ||| BindingFlags.Instance ||| BindingFlags.GetField)
         for (index, fieldInfo) in Seq.indexed fields do
             let fieldModel = metaType.AddField(1 + index, fieldInfo.Name)
             fieldModel.BackingMember <- fieldInfo
             fieldModel.OverwriteList <- true
             fieldModel.Name <- fieldInfo.Name.TrimStart('_').TrimEnd('@') // Still not perfect --- F# allows pretty wild names (some cause protobuf to fail)
 
-    let private processFieldsAndCreateFieldSetters (typeToAdd: Type) (metaType: MetaType) (model : RuntimeTypeModel) =
-        let fields = typeToAdd.GetFields(BindingFlags.Public ||| BindingFlags.NonPublic ||| BindingFlags.Instance ||| BindingFlags.GetField)
-        metaType.UseConstructor <- false
-        match CodeGen.getTypeConstructionMethod typeToAdd fields with
-        | CodeGen.TypeConstructionStrategy.ObjectSurrogate surrogateType ->
-            metaType.SetSurrogate surrogateType
-        | CodeGen.TypeConstructionStrategy.CustomFactoryMethod factoryMethod ->
-            addFieldsToMetaType metaType fields
-            metaType.SetFactory factoryMethod |> ignore
-        | CodeGen.TypeConstructionStrategy.NoCustomConstructor ->
-            addFieldsToMetaType metaType fields
+        let zeroValuesForFields = ZeroValues.calculateApplicableFields fields
+        if Array.length zeroValuesForFields > 0 then
+            metaType.SetFactory(CodeGen.getFactory typeToAdd zeroValuesForFields) |> ignore
 
-        for field in fields do registerOptionTypesIntoModel field.FieldType None model
+        metaType
 
-    let registerUnionRuntimeTypeIntoModel' (unionType: Type) (model: RuntimeTypeModel) =
-        let metaType = model.Add(unionType, true)
-        let surrogateType = CodeGen.getUnionSurrogate unionType
-        metaType.SetSurrogate surrogateType
-        for subtype in CodeGen.relevantUnionSubtypes unionType do
-            model.Add(subtype, false).SetSurrogate(surrogateType)
-        model
-
-    let registerUnionRuntimeTypeIntoModel (unionType: Type) (model: RuntimeTypeModel) =
+    let private registerUnionDirectly (unionType: Type) (model: RuntimeTypeModel) =
         let unionCaseData = FSharpType.GetUnionCases(unionType, true)
 
         // Register the supertype in all cases
-        let mt = model.Add(unionType, true)
-        mt.UseConstructor <- false
-        processFieldsAndCreateFieldSetters unionType mt model |> ignore
+        let mt = processFieldsAndCreateFieldSetters unionType model
 
         // If there are no fields in any properties then we can assume the F# compiler has compiled
         // the class in a non-flat fashion. Structs are still compiled in a flat way (F# 4.1+ struct DU's).
@@ -109,35 +95,69 @@ module Serialiser =
                     // The union may be a supertype union with no values hence no subtype. Should use the supertype as appropriate and skip this case.
                     match typeToAddOpt with
                     | Some(typeToAdd) ->
-                        let caseTypeModel = model.Add(typeToAdd, false)
+                        let caseTypeModel = processFieldsAndCreateFieldSetters typeToAdd model
+                        caseTypeModel.Name <- ucd.Name
                         let tag = 1000 + ucd.Tag
                         mt.AddSubType(tag, typeToAdd) |> ignore
-                        caseTypeModel.UseConstructor <- false
-                        caseTypeModel.Name <- ucd.Name
-                        processFieldsAndCreateFieldSetters typeToAdd caseTypeModel model |> ignore
                     | None -> ()
-        model
 
-    let registerUnionIntoModel<'tunion> model = registerUnionRuntimeTypeIntoModel typeof<'tunion> model
+    let private internalRegister useSurrogateForReferenceUnions (runtimeType: Type) (model: RuntimeTypeModel) =
+        match runtimeType with
+        | recordType when FSharpType.IsRecord(recordType, true) ->
+            let fields = FSharpType.GetRecordFields(recordType, true)
+            if recordType.IsValueType && fields |> Array.exists (fun pi -> ZeroValues.isApplicableTo pi.PropertyType) then
+                registerSurrogate recordType model |> ignore
+            else
+                processFieldsAndCreateFieldSetters recordType model |> ignore
 
-    let registerRecordRuntimeTypeIntoModel (runtimeType: Type) (model: RuntimeTypeModel) =
-        let metaType = model.Add(runtimeType, false)
-        metaType.UseConstructor <- false
-        processFieldsAndCreateFieldSetters runtimeType metaType model |> ignore
-        model
+            for field in fields do
+                registerOptionTypesIntoModel field.PropertyType None model
 
-    let registerRecordIntoModel<'t> (model: RuntimeTypeModel) = registerRecordRuntimeTypeIntoModel typeof<'t> model
+        | unionType when FSharpType.IsUnion(unionType, true) ->
+            if unionType.IsGenericType && unionType.GetGenericTypeDefinition() = typedefof<Option<_>> then
+                registerOptionTypesIntoModel unionType None model
+            elif unionType.IsValueType || useSurrogateForReferenceUnions then
+                let surrogateType = registerSurrogate unionType model
+                for subtype in CodeGen.relevantUnionSubtypes unionType do
+                    model.Add(subtype, false).SetSurrogate(surrogateType)
+            else
+                registerUnionDirectly unionType model
+
+            for caseInfo in FSharpType.GetUnionCases(unionType, true) do
+                for field in caseInfo.GetFields() do
+                    registerOptionTypesIntoModel field.PropertyType None model
+
+        | _ ->
+            model.Add(runtimeType, true) |> ignore
+
 
     let registerRuntimeTypeIntoModel (runtimeType: Type) (model: RuntimeTypeModel) =
-        if FSharpType.IsRecord (runtimeType, true)
-        then registerRecordRuntimeTypeIntoModel runtimeType model
-        elif FSharpType.IsUnion (runtimeType, true)
-        then registerUnionRuntimeTypeIntoModel runtimeType model
-        else
-            model.Add(runtimeType, true) |> ignore
-            model
+        internalRegister false runtimeType model
+        model
 
-    let registerTypeIntoModel<'t> (model: RuntimeTypeModel) = registerRuntimeTypeIntoModel typeof<'t> model
+    let registerTypeIntoModel<'t> (model: RuntimeTypeModel) =
+        registerRuntimeTypeIntoModel typeof<'t> model
+
+
+    let registerUnionRuntimeTypeIntoModel (unionType: Type) (model: RuntimeTypeModel) =
+        if FSharpType.IsUnion(unionType, true) then
+            registerRuntimeTypeIntoModel unionType model
+        else
+            failwithf "registerUnionRuntimeTypeIntoModel: %A is not a union" unionType
+
+    let registerUnionIntoModel<'tunion> model =
+        registerUnionRuntimeTypeIntoModel typeof<'tunion> model
+
+
+    let registerRecordRuntimeTypeIntoModel (recordType: Type) (model: RuntimeTypeModel) =
+        if FSharpType.IsRecord(recordType, true) then
+            registerRuntimeTypeIntoModel recordType model
+        else
+            failwithf "registerRecordRuntimeTypeIntoModel: %A is not a record" recordType
+
+    let registerRecordIntoModel<'t> (model: RuntimeTypeModel) =
+        registerRecordRuntimeTypeIntoModel typeof<'t> model
+
 
     let serialise (model: RuntimeTypeModel) (stream: Stream) (o: 't) = model.Serialize(stream, o)
 

--- a/src/ProtoBuf.FSharp/Surrogates.fs
+++ b/src/ProtoBuf.FSharp/Surrogates.fs
@@ -1,10 +1,13 @@
 namespace ProtoBuf.FSharp.Surrogates
 
+open ProtoBuf
+open ProtoBuf.Meta
 open ProtoBuf.FSharp.ZeroValues
 
-type [<CLIMutable>] Optional<'t> =
-    { HasValue: bool
-      Item: 't }
+[<Struct; CLIMutable; ProtoContract()>]
+type Optional<'t> =
+    { [<ProtoMember(1)>] HasValue: bool
+      [<ProtoMember(2)>] Item: 't }
 
     static member op_Implicit (o: 't option) =
         match o with
@@ -16,3 +19,7 @@ type [<CLIMutable>] Optional<'t> =
         | false -> None
         | true when isApplicableTo typeof<'t> -> w.Item |> fixZeroValue |> Some
         | true -> Some w.Item
+
+    static member RegisterIntoModel (model : RuntimeTypeModel) =
+        let surrogateModelType = model.Add(typeof<Optional<'t>>, true)
+        surrogateModelType.Name <- "Optional" + typeof<'t>.Name

--- a/test/ProtoBuf.FSharp.Unit/TestUnionRoundtrip.fs
+++ b/test/ProtoBuf.FSharp.Unit/TestUnionRoundtrip.fs
@@ -59,6 +59,12 @@ module ExampleTypesInsideModule =
     | CaseThreee of singleData: string
     | CaseFour
 
+    [<Struct; TestName("Value union with no data inside")>]
+    type ValueUnionNoData =
+    | CaseOne
+    | CaseTwo
+    | CaseThreee
+
 module TestUnionRoundtrip =
 
     let propertyToTest<'t when 't : equality> (typeToTest: 't) = 
@@ -74,8 +80,11 @@ module TestUnionRoundtrip =
     
     let buildTest<'t when 't : equality>() = 
         let config = { Config.QuickThrowOnFailure with Arbitrary = [ typeof<DataGenerator> ] }
-        let testNameAttribute = typeof<'t>.GetCustomAttributes(typeof<TestNameAttribute>, true) |> Seq.head :?> TestNameAttribute
-        testCase testNameAttribute.Name <| fun () -> Check.One(config, propertyToTest<'t>)
+        let name =
+            match typeof<'t>.GetCustomAttributes(typeof<TestNameAttribute>, true) with
+            | [| :? TestNameAttribute as attr |] -> attr.Name
+            | _ -> sprintf "Union case for %A" typeof<'t>
+        testCase name <| fun () -> Check.One(config, propertyToTest<'t>)
 
     // This test is just to show how the schema will be look like for other consumers. It is expected to fail so isn't used normally.
     let manualTest = 
@@ -103,4 +112,8 @@ module TestUnionRoundtrip =
               buildTest<ExampleTypesInsideModule.SerialisableOption<string>>() 
               buildTest<ExampleTypesInsideModule.Wrapper<string>>()
               buildTest<ExampleTypesInsideModule.UnionNine>()
+              buildTest<ValueOption<string>>()
+              buildTest<Result<int, bool>>()
+              buildTest<Result<string, int[]>>()
+              buildTest<ExampleTypesInsideModule.ValueUnionNoData>()
               ]


### PR DESCRIPTION
It's a bit wasteful, but seems to work. There's also some weird error on union like this:
```F#
[<Struct>]
type U = | C
```
but I think it may be protobuf's bug.